### PR TITLE
add webserver hostname var when calling role

### DIFF
--- a/netbox_unified.yml
+++ b/netbox_unified.yml
@@ -26,6 +26,7 @@
 
      - name: netbox-web
        netbox_install_directory: "{{ install_dir }}"
+       netbox_webserver_name: "{{ hostname }}"
        ### This is a self-signed cert, make your own for production...
        netbox_webserver_ssl_crt: |
          -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
I think this is needed for production, otherwise the web role var `netbox_webserver_name` defaults to `localhost`.